### PR TITLE
Gusto access: homepage extraction

### DIFF
--- a/.mise/tasks/gusto/home
+++ b/.mise/tasks/gusto/home
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+#MISE description="View Gusto homepage data"
+#USAGE flag "--json" help="Output raw JSON instead of formatted table"
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$SCRIPT_DIR/../../../scripts/gusto/home.mjs"
+
+STDERR_FILE=$(mktemp)
+trap "rm -f $STDERR_FILE" EXIT
+
+OUTPUT=$(shimmer browser:run "$SCRIPT" 2>"$STDERR_FILE" | grep '^{') || true
+
+if [ -z "$OUTPUT" ]; then
+  echo "Failed to fetch Gusto homepage." >&2
+  if [ -s "$STDERR_FILE" ]; then
+    cat "$STDERR_FILE" >&2
+  fi
+  exit 1
+fi
+
+if [ "${usage_json}" = "true" ]; then
+  echo "$OUTPUT"
+else
+  echo ""
+  echo "Title: $(echo "$OUTPUT" | jq -r '.title')"
+  echo ""
+
+  NAV_COUNT=$(echo "$OUTPUT" | jq '.navLinks | length')
+  if [ "$NAV_COUNT" -gt 0 ]; then
+    echo "Navigation:"
+    echo "$OUTPUT" | jq -r '.navLinks[] | "  \(.text)"'
+    echo ""
+  fi
+
+  HEADING_COUNT=$(echo "$OUTPUT" | jq '.headings | length')
+  if [ "$HEADING_COUNT" -gt 0 ]; then
+    echo "Headings:"
+    echo "$OUTPUT" | jq -r '.headings[] | "  [\(.level)] \(.text)"'
+    echo ""
+  fi
+
+  CTA_COUNT=$(echo "$OUTPUT" | jq '.ctas | length')
+  if [ "$CTA_COUNT" -gt 0 ]; then
+    echo "CTAs:"
+    echo "$OUTPUT" | jq -r '.ctas[] | "  \(.text)"'
+    echo ""
+  fi
+fi

--- a/.mise/tasks/gusto/login
+++ b/.mise/tasks/gusto/login
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+#MISE description="Bootstrap Gusto authentication"
+set -eo pipefail
+
+# Detect agent name
+AGENT=$(git config user.email | sed -n 's/@ricon\.family//p')
+if [ -z "$AGENT" ]; then
+  echo "Error: Could not detect agent name from git config" >&2
+  exit 1
+fi
+
+AUTH_DIR="$HOME/.config/shimmer/browser/$AGENT"
+AUTH_FILE="$AUTH_DIR/gusto.com.json"
+
+if [ -f "$AUTH_FILE" ]; then
+  AGE_MIN=$(( ($(date +%s) - $(stat -f%m "$AUTH_FILE")) / 60 ))
+  echo "Auth file exists for $AGENT (${AGE_MIN}m old): $AUTH_FILE"
+  exit 0
+fi
+
+# Create empty auth state for public pages
+mkdir -p "$AUTH_DIR"
+echo '{"cookies":[],"origins":[]}' > "$AUTH_FILE"
+chmod 600 "$AUTH_FILE"
+
+echo "Created empty auth state for $AGENT: $AUTH_FILE"
+echo "This allows access to public pages only."
+echo ""
+echo "For authenticated access, run:"
+echo "  shimmer browser:login --interactive gusto.com"

--- a/mise.toml
+++ b/mise.toml
@@ -1,2 +1,4 @@
 [tools]
 usage = "latest"
+jq = "latest"
+gum = "latest"

--- a/scripts/gusto/home.mjs
+++ b/scripts/gusto/home.mjs
@@ -1,0 +1,35 @@
+export const site = 'gusto.com';
+
+export default async function({ page }) {
+  await page.goto('https://gusto.com', { waitUntil: 'domcontentloaded' });
+
+  // Wait for Cloudflare challenge to resolve (title changes from "Just a moment...")
+  await page.waitForFunction(() => document.title !== 'Just a moment...', { timeout: 60000 });
+  await page.waitForTimeout(2000);
+
+  const data = await page.evaluate(() => {
+    const title = document.title;
+
+    // Extract navigation links
+    const navLinks = [...document.querySelectorAll('nav a')].map(a => ({
+      text: a.textContent?.trim(),
+      href: a.href,
+    })).filter(l => l.text);
+
+    // Extract main headings
+    const headings = [...document.querySelectorAll('h1, h2')].map(h => ({
+      level: h.tagName.toLowerCase(),
+      text: h.textContent?.trim(),
+    })).filter(h => h.text);
+
+    // Extract CTA buttons/links
+    const ctas = [...document.querySelectorAll('a[href*="sign"], a[href*="demo"], a[href*="pricing"], button')].map(el => ({
+      text: el.textContent?.trim(),
+      href: el.href || null,
+    })).filter(c => c.text);
+
+    return { title, navLinks, headings, ctas };
+  });
+
+  console.log(JSON.stringify(data));
+}


### PR DESCRIPTION
## Summary

- `gusto:login` — bootstraps empty auth state for public page access
- `gusto:home` — navigates to gusto.com, extracts structured data (nav links, headings, CTAs) as JSON
- Adds `jq` and `gum` as mise tool dependencies

## Status

Proof of concept works — successfully extracts data from gusto.com's public page (headed mode). Headless hits Cloudflare challenges.

## Blocked on

- **Session reuse (#6)** — each task currently launches a new browser. For fine-grained page navigation this is too slow. Need to figure out session sharing before adding more pages.
- **Authenticated pages** — need interactive login to Gusto, plus session reuse to make it practical.

## Next steps

1. Solve session reuse (#6)
2. Interactive login to Gusto
3. Map authenticated pages (home dashboard, tasks, transactions, payments)
4. Add sub-actions (e.g. `gusto:home:transfer`)
5. Test infrastructure

🤖 Generated with [Claude Code](https://claude.com/claude-code)