### PR TITLE
Improve GitHub token rotation diagnostics

### DIFF
--- a/.mise/tasks/github/api/token-check
+++ b/.mise/tasks/github/api/token-check
@@ -13,18 +13,26 @@ fi
 # gh api -i returns headers + JSON body together, so --jq can't be used.
 # Parse the login field from the raw JSON response.
 USER=$(echo "$RESPONSE" | grep -o '"login"\s*:\s*"[^"]*"' | head -1 | cut -d'"' -f4)
-EXPIRY=$(echo "$RESPONSE" | grep -i 'github-authentication-token-expiration:' | sed 's/.*: //' | tr -d '\r')
+EXPIRY=$(echo "$RESPONSE" | awk '
+  tolower($0) ~ /^github-authentication-token-expiration:/ {
+    sub(/^[^:]*:[[:space:]]*/, "")
+    sub(/\r$/, "")
+    print
+    exit
+  }
+')
 
 if [ -z "$EXPIRY" ]; then
   echo "✓ $USER — no expiration"
   exit 0
 fi
 
-# GitHub's header format: "2026-04-16 06:02:20 UTC"
-# macOS uses date -j -f, Linux/GNU uses date -d. Try both.
-EXPIRY_EPOCH=$(date -j -f "%Y-%m-%d %H:%M:%S %Z" "$EXPIRY" "+%s" 2>/dev/null \
-  || date -d "$EXPIRY" "+%s" 2>/dev/null \
-  || echo "")
+# GitHub's header format: "2026-04-16 06:02:20 UTC".
+# Use Node's Date parser instead of branching across BSD/GNU date flags.
+EXPIRY_EPOCH=$(node -e '
+  const parsed = Date.parse(process.argv[1]);
+  if (!Number.isNaN(parsed)) console.log(Math.floor(parsed / 1000));
+' "$EXPIRY")
 if [ -n "$EXPIRY_EPOCH" ]; then
   NOW=$(date "+%s")
   DAYS_LEFT=$(( (EXPIRY_EPOCH - NOW) / 86400 ))

--- a/.mise/tasks/github/token/list
+++ b/.mise/tasks/github/token/list
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+#MISE description="List visible GitHub classic PAT names"
+#USAGE flag "--login-id <id>" help="Identity used for email verification polling"
+#USAGE flag "--json" help="Output raw JSON instead of a table"
+#USAGE flag "--record" help="Record page artifacts for test fixtures"
+
+set -euo pipefail
+
+PROJECT_DIR="${MISE_CONFIG_ROOT:?MISE_CONFIG_ROOT not set}"
+LOGIN_ID="${usage_login_id:-${GIT_AUTHOR_NAME:-github}}"
+
+if [ -z "${GITHUB_USERNAME:-}" ] || [ -z "${GITHUB_PASSWORD:-}" ]; then
+  echo "ERROR: GITHUB_USERNAME and GITHUB_PASSWORD env vars required." >&2
+  exit 1
+fi
+
+if [ "${usage_record:-false}" = "true" ]; then
+  RECORD_DIR="$PROJECT_DIR/test/fixtures/$(date +%Y%m%d-%H%M%S)"
+  export WEBSITES_RECORD_DIR="$RECORD_DIR"
+  echo "Recording artifacts to: $RECORD_DIR" >&2
+  echo "" >&2
+fi
+
+OUTPUT=$(browser run "$PROJECT_DIR/scripts/github/token-list.mjs" -- "$LOGIN_ID" 2>&1) || {
+  echo "$OUTPUT" >&2
+  exit 1
+}
+
+JSON=$(echo "$OUTPUT" | awk '/^TOKENS_JSON:/ { sub(/^TOKENS_JSON:/, ""); print; found=1 } END { exit found ? 0 : 1 }') || {
+  echo "$OUTPUT" >&2
+  echo "ERROR: Could not extract token list JSON from script output" >&2
+  exit 1
+}
+
+# Keep browser/login diagnostics visible without polluting --json stdout.
+echo "$OUTPUT" | awk '!/^TOKENS_JSON:/' >&2
+
+if [ "${usage_json:-false}" = "true" ]; then
+  echo "$JSON" | jq .
+  exit 0
+fi
+
+if [ "$(echo "$JSON" | jq 'length')" -eq 0 ]; then
+  echo "No classic tokens found."
+  exit 0
+fi
+
+ROWS=$(echo "$JSON" | jq -r '.[] | [.id, .name, ((.status // []) | join(" | "))] | @tsv')
+
+if command -v gum >/dev/null 2>&1; then
+  echo "$ROWS" | gum table --separator $'\t' --columns "ID,Name,Status" --print --border rounded
+else
+  printf 'ID\tName\tStatus\n'
+  echo "$ROWS"
+fi

--- a/.mise/tasks/github/token/rotate
+++ b/.mise/tasks/github/token/rotate
@@ -19,8 +19,8 @@ fi
 if [ "${usage_record:-false}" = "true" ]; then
   RECORD_DIR="$PROJECT_DIR/test/fixtures/$(date +%Y%m%d-%H%M%S)"
   export WEBSITES_RECORD_DIR="$RECORD_DIR"
-  echo "Recording artifacts to: $RECORD_DIR"
-  echo ""
+  echo "Recording artifacts to: $RECORD_DIR" >&2
+  echo "" >&2
 fi
 
 # --- Run the Patchright script ---

--- a/.mise/tasks/github/token/rotate
+++ b/.mise/tasks/github/token/rotate
@@ -1,11 +1,13 @@
 #!/usr/bin/env bash
 #MISE description="Regenerate a GitHub classic PAT by name"
-#USAGE arg "<token-name>" help="Name of the token to regenerate"
+#USAGE arg "<name>" help="Name of the token to regenerate"
+#USAGE flag "--login-id <id>" help="Identity used for email verification polling"
 #USAGE flag "--record" help="Record page artifacts for test fixtures"
 
-set -e
+set -euo pipefail
 
-TOKEN_NAME="${usage_token_name:?Usage: websites github:token:rotate <token-name>}"
+TOKEN_NAME="${usage_name:?Usage: websites github:token:rotate <name>}"
+LOGIN_ID="${usage_login_id:-${GIT_AUTHOR_NAME:-$TOKEN_NAME}}"
 PROJECT_DIR="${MISE_CONFIG_ROOT:?MISE_CONFIG_ROOT not set}"
 
 if [ -z "${GITHUB_USERNAME:-}" ] || [ -z "${GITHUB_PASSWORD:-}" ]; then
@@ -23,7 +25,7 @@ fi
 
 # --- Run the Patchright script ---
 OUTPUT=$(
-  browser run "$PROJECT_DIR/scripts/github/token-rotate.mjs" -- "$TOKEN_NAME" \
+  browser run "$PROJECT_DIR/scripts/github/token-rotate.mjs" -- "$TOKEN_NAME" "$LOGIN_ID" \
   2>&1
 ) || {
   echo "$OUTPUT" >&2
@@ -32,8 +34,10 @@ OUTPUT=$(
 
 echo "$OUTPUT" >&2
 
-# Extract and output just the token
-NEW_TOKEN=$(echo "$OUTPUT" | grep '^TOKEN:' | tail -1 | sed 's/^TOKEN://')
+# Extract and output just the token.
+# Use awk instead of a grep pipeline so pipefail doesn't bypass the explicit
+# validation/error message below when the browser script exits 0 without TOKEN:.
+NEW_TOKEN=$(echo "$OUTPUT" | awk -F'TOKEN:' '/^TOKEN:/ { value=$2 } END { print value }')
 
 if [ -z "$NEW_TOKEN" ] || ! echo "$NEW_TOKEN" | grep -q '^ghp_'; then
   echo "ERROR: Could not extract token from script output" >&2

--- a/.mise/tasks/test
+++ b/.mise/tasks/test
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#MISE description="Run BATS tests"
+#USAGE arg "[args]..." var=#true help="Test suites or bats arguments"
+#USAGE example "mise run test" header="Run all tests"
+#USAGE example "mise run test github-token-tasks" header="Run a specific suite by name"
+#USAGE example "mise run test -- --filter token" header="Filter tests by name"
+
+set -euo pipefail
+
+TEST_DIR="$MISE_CONFIG_ROOT/test"
+
+args=()
+has_target=false
+
+for arg in "$@"; do
+  if [[ "$arg" != -* && "$arg" != *.bats && -f "$TEST_DIR/$arg.bats" ]]; then
+    args+=("$TEST_DIR/$arg.bats")
+    has_target=true
+  else
+    [[ "$arg" == *.bats || -d "$arg" ]] && has_target=true
+    args+=("$arg")
+  fi
+done
+
+if ! $has_target; then
+  args+=("$TEST_DIR/")
+fi
+
+bats "${args[@]}"

--- a/mise.toml
+++ b/mise.toml
@@ -2,3 +2,5 @@
 usage = "latest"
 jq = "latest"
 gum = "latest"
+node = "latest"
+bats = "1.13.0"

--- a/scripts/github/login.mjs
+++ b/scripts/github/login.mjs
@@ -29,8 +29,15 @@ export async function login(page, { agent, username, password }) {
   const postLoginUrl = page.url();
   record(`login-post-submit-${agent}.html`, await page.content());
 
-  // Check for device verification
-  if (postLoginUrl.includes('/sessions/two-factor') || postLoginUrl.includes('/login/device')) {
+  // Check for device verification. GitHub has used multiple URL shapes for
+  // this flow; the visible OTP input is more reliable than URL matching alone.
+  const otpInput = page.locator('#otp, input[name="otp"], input[autocomplete="one-time-code"]').first();
+  const needsDeviceVerification =
+    postLoginUrl.includes('/sessions/two-factor') ||
+    postLoginUrl.includes('/login/device') ||
+    await otpInput.isVisible({ timeout: 3000 }).catch(() => false);
+
+  if (needsDeviceVerification) {
     console.log('Device verification required. Polling email...');
 
     const code = await pollForVerificationCode(agent);
@@ -40,8 +47,6 @@ export async function login(page, { agent, username, password }) {
 
     console.error('Got verification code.');
 
-    // GitHub device verification: look for the OTP input
-    const otpInput = page.locator('#otp, input[name="otp"], input[autocomplete="one-time-code"]').first();
     if (await otpInput.isVisible({ timeout: 5000 }).catch(() => false)) {
       await otpInput.fill(code);
     } else {
@@ -49,19 +54,30 @@ export async function login(page, { agent, username, password }) {
       await textInput.fill(code);
     }
 
-    // Submit
-    const submitBtn = page.locator('button[type="submit"]:visible').first();
+    // GitHub usually auto-submits the device code, but pressing Enter keeps the
+    // flow moving when auto-submit does not fire in automation.
+    await page.keyboard.press('Enter').catch(() => {});
+
+    const submitBtn = page.locator('button[type="submit"]:visible, input[type="submit"]:visible').first();
     if (await submitBtn.isVisible({ timeout: 2000 }).catch(() => false)) {
       await submitBtn.click();
     }
 
-    // Wait for redirect past verification
+    // Wait for redirect past verification.
     await page.waitForURL(url => {
       const s = url.toString();
       return !s.includes('/login') && !s.includes('/sessions');
     }, { timeout: 30000 });
 
     record(`login-post-verify-${agent}.html`, await page.content());
+  }
+
+  const loginFormStillVisible = await page.locator('input[name="login"], input[name="password"]').first()
+    .isVisible({ timeout: 1000 })
+    .catch(() => false);
+  if (loginFormStillVisible) {
+    record(`login-failed-${agent}.html`, await page.content());
+    throw new Error(`GitHub login did not complete. Current URL: ${page.url()}`);
   }
 
   console.log('Logged in successfully.');

--- a/scripts/github/token-list.mjs
+++ b/scripts/github/token-list.mjs
@@ -1,0 +1,39 @@
+// token-list.mjs — List visible classic GitHub PATs
+//
+// Assumes GITHUB_USERNAME and GITHUB_PASSWORD env vars are set.
+// Logs in, navigates to the classic tokens page, and emits machine-readable
+// token metadata. Does not print token secret values.
+//
+// Usage: browser run ./scripts/github/token-list.mjs -- <login-id>
+
+import { login } from './login.mjs';
+import { record } from '../record.mjs';
+import { listClassicTokens } from './tokens.mjs';
+
+export default async function({ page, args }) {
+  const loginId = args[0] || process.env.WEBSITES_LOGIN_ID || 'github';
+
+  const username = process.env.GITHUB_USERNAME;
+  const password = process.env.GITHUB_PASSWORD;
+  if (!username || !password) {
+    console.error('GITHUB_USERNAME and GITHUB_PASSWORD env vars required');
+    process.exit(1);
+  }
+
+  await login(page, { agent: loginId, username, password });
+
+  await page.goto('https://github.com/settings/tokens');
+  await page.waitForLoadState('domcontentloaded');
+  record(`tokens-page-${loginId}.html`, await page.content());
+
+  const loginFormStillVisible = await page.locator('input[name="login"], input[name="password"]').first()
+    .isVisible({ timeout: 1000 })
+    .catch(() => false);
+  if (loginFormStillVisible) {
+    console.error(`Not authenticated after login; redirected to ${page.url()}`);
+    process.exit(1);
+  }
+
+  const tokens = await listClassicTokens(page);
+  console.log(`TOKENS_JSON:${JSON.stringify(tokens)}`);
+}

--- a/scripts/github/token-rotate.mjs
+++ b/scripts/github/token-rotate.mjs
@@ -1,34 +1,30 @@
 // token-rotate.mjs — Regenerate a classic GitHub PAT
 //
 // Assumes GITHUB_USERNAME and GITHUB_PASSWORD env vars are set.
-// Logs in, navigates to the classic tokens page, regenerates the agent's token,
+// Logs in, navigates to the classic tokens page, regenerates a named token,
 // and outputs TOKEN:<value> on the last line for the calling task to capture.
 //
-// Usage: browser run --headed ./scripts/github/token-rotate.mjs -- <agent-name>
+// Usage: browser run --headed ./scripts/github/token-rotate.mjs -- <token-name> [login-id]
 
 import { login } from './login.mjs';
 import { record } from '../record.mjs';
+import {
+  findClassicTokenByName,
+  listClassicTokens,
+  parseTokenFromText,
+  parseTokenId,
+} from './tokens.mjs';
 
-// --- Pure functions (testable) ---
-
-// Extract a classic PAT (ghp_...) from page text or HTML.
-export function parseTokenFromText(text) {
-  const match = text.match(/(ghp_[a-zA-Z0-9]+)/);
-  return match ? match[1] : null;
-}
-
-// Extract a token ID from a /settings/tokens/<id> href.
-export function parseTokenId(href) {
-  const match = href.match(/\/tokens\/(\d+)/);
-  return match ? match[1] : null;
-}
+// Re-export pure functions for compatibility with existing tests/importers.
+export { parseTokenFromText, parseTokenId };
 
 // --- Script entry point ---
 
 export default async function({ page, args }) {
-  const agent = args[0];
-  if (!agent) {
-    console.error('Usage: pass agent name as first argument');
+  const tokenName = args[0];
+  const loginId = args[1] || process.env.WEBSITES_LOGIN_ID || tokenName;
+  if (!tokenName) {
+    console.error('Usage: pass token name as first argument');
     process.exit(1);
   }
 
@@ -40,41 +36,45 @@ export default async function({ page, args }) {
   }
 
   // --- Login ---
-  await login(page, { agent, username, password });
+  await login(page, { agent: loginId, username, password });
 
   // --- Navigate to classic tokens page ---
   await page.goto('https://github.com/settings/tokens');
   await page.waitForLoadState('domcontentloaded');
-  record(`tokens-page-${agent}.html`, await page.content());
+  record(`tokens-page-${loginId}.html`, await page.content());
 
-  // --- Find the agent's token ---
-  const tokenLink = page.locator(`a[href*="/settings/tokens/"]:has-text("${agent}")`).first();
-  if (!await tokenLink.isVisible({ timeout: 5000 }).catch(() => false)) {
-    console.error(`Token named "${agent}" not found.`);
+  const loginFormStillVisible = await page.locator('input[name="login"], input[name="password"]').first()
+    .isVisible({ timeout: 1000 })
+    .catch(() => false);
+  if (loginFormStillVisible) {
+    console.error(`Not authenticated after login; redirected to ${page.url()}`);
+    process.exit(1);
+  }
 
-    const allTokenLinks = page.locator('a[href*="/settings/tokens/"]');
-    const count = await allTokenLinks.count();
-    console.error(`Found ${count} token(s) on page:`);
-    for (let i = 0; i < count; i++) {
-      const text = await allTokenLinks.nth(i).textContent();
-      console.error(`  - ${text.trim()}`);
+  // --- Find the token by exact visible name ---
+  const tokens = await listClassicTokens(page);
+  const token = findClassicTokenByName(tokens, tokenName);
+  if (!token) {
+    console.error(`Token named "${tokenName}" not found.`);
+    console.error(`Found ${tokens.length} token(s) on page:`);
+    for (const visibleToken of tokens) {
+      console.error(`  - ${visibleToken.id}\t${visibleToken.name}`);
     }
     process.exit(1);
   }
 
-  const tokenHref = await tokenLink.getAttribute('href');
-  const tokenId = parseTokenId(tokenHref);
+  const tokenId = token.id;
   if (!tokenId) {
-    console.error(`Could not extract token ID from href: ${tokenHref}`);
+    console.error(`Could not extract token ID for token: ${tokenName}`);
     process.exit(1);
   }
 
-  console.log(`Found token "${agent}" (ID: ${tokenId}). Regenerating...`);
+  console.log(`Found token "${tokenName}" (ID: ${tokenId}). Regenerating...`);
 
   // --- Regenerate ---
   await page.goto(`https://github.com/settings/tokens/${tokenId}/regenerate`);
   await page.waitForLoadState('domcontentloaded');
-  record(`regenerate-page-${agent}.html`, await page.content());
+  record(`regenerate-page-${loginId}.html`, await page.content());
 
   // Set expiration to 30 days
   const expirationSelect = page.locator('select#token_expiration, select[name*="expiration"]').first();
@@ -100,7 +100,7 @@ export default async function({ page, args }) {
   await tokenDisplayLocator.waitFor({ state: 'visible', timeout: 15000 }).catch(() => {
     console.error('Warning: token display element not found within timeout, will try fallback methods.');
   });
-  record(`regenerated-page-${agent}.html`, await page.content());
+  record(`regenerated-page-${loginId}.html`, await page.content());
 
   // --- Capture the new token ---
   let newToken = null;

--- a/scripts/github/tokens.mjs
+++ b/scripts/github/tokens.mjs
@@ -1,0 +1,52 @@
+// tokens.mjs — Helpers for GitHub classic PAT pages
+
+// Extract a classic PAT (ghp_...) from page text or HTML.
+export function parseTokenFromText(text) {
+  const match = text.match(/(ghp_[a-zA-Z0-9]+)/);
+  return match ? match[1] : null;
+}
+
+// Extract a token ID from a /settings/tokens/<id> href.
+export function parseTokenId(href) {
+  const match = href.match(/\/tokens\/(\d+)/);
+  return match ? match[1] : null;
+}
+
+function normalizeText(text) {
+  return (text || '').trim().replace(/\s+/g, ' ');
+}
+
+function unique(items) {
+  return [...new Set(items.filter(Boolean))];
+}
+
+export async function listClassicTokens(page) {
+  const tokenRows = page.locator('.access-token[data-id]');
+  const rowCount = await tokenRows.count();
+  const tokens = [];
+
+  for (let i = 0; i < rowCount; i++) {
+    const row = tokenRows.nth(i);
+    const id = await row.getAttribute('data-id');
+    if (!id) continue;
+
+    const nameLink = row.locator('.token-description strong a[href*="/settings/tokens/"]').first();
+    const href = await nameLink.getAttribute('href');
+    const parsedId = parseTokenId(href || '');
+    const name = normalizeText(await nameLink.textContent());
+    if (!name) continue;
+
+    const status = unique(
+      (await row.locator('.color-fg-attention, .last-used').allTextContents())
+        .map(normalizeText)
+    );
+
+    tokens.push({ id: parsedId || id, name, status });
+  }
+
+  return tokens;
+}
+
+export function findClassicTokenByName(tokens, name) {
+  return tokens.find(token => token.name === name) || null;
+}

--- a/test/github-parsing.bats
+++ b/test/github-parsing.bats
@@ -155,6 +155,26 @@ run_js() {
   [ "$output" = "ghp_oldtoken123" ]
 }
 
+# --- findClassicTokenByName ---
+
+@test "findClassicTokenByName: requires exact token name match" {
+  run_js "
+    import { findClassicTokenByName } from '$SCRIPTS_DIR/tokens.mjs';
+    const tokens = [{ id: '1', name: 'ikma-old' }, { id: '2', name: 'ikma' }];
+    console.log(JSON.stringify(findClassicTokenByName(tokens, 'ikma')));
+  "
+  [ "$output" = '{"id":"2","name":"ikma"}' ]
+}
+
+@test "findClassicTokenByName: does not substring match" {
+  run_js "
+    import { findClassicTokenByName } from '$SCRIPTS_DIR/tokens.mjs';
+    const tokens = [{ id: '1', name: 'or-personal' }];
+    console.log(findClassicTokenByName(tokens, 'or'));
+  "
+  [ "$output" = "null" ]
+}
+
 # --- parseTokenId ---
 
 @test "parseTokenId: extracts ID from settings URL" {

--- a/test/github-token-tasks.bats
+++ b/test/github-token-tasks.bats
@@ -63,3 +63,14 @@ EOF
   [ "$status" -ne 0 ]
   [[ "$stderr" == *"ERROR: Could not extract token from script output"* ]]
 }
+
+@test "github:token:rotate --record keeps stdout token-only" {
+  write_fake_browser 'printf "%s\n" "browser diagnostic" "TOKEN:ghp_abc123"'
+
+  run --separate-stderr websites github:token:rotate ikma --record
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "ghp_abc123" ]
+  [[ "$stderr" == *"Recording artifacts to:"* ]]
+  [[ "$stderr" == *"browser diagnostic"* ]]
+}

--- a/test/github-token-tasks.bats
+++ b/test/github-token-tasks.bats
@@ -1,0 +1,65 @@
+#!/usr/bin/env bats
+
+bats_require_minimum_version 1.5.0
+
+REPO_DIR="${REPO_DIR:-$(cd "$BATS_TEST_DIRNAME/.." && pwd)}"
+
+setup() {
+  TMPBIN="$BATS_TEST_TMPDIR/bin"
+  mkdir -p "$TMPBIN"
+  export TMPBIN
+  export GITHUB_USERNAME="test-user"
+  export GITHUB_PASSWORD="test-pass"
+  export GIT_AUTHOR_NAME="tester"
+}
+
+websites() {
+  cd "$REPO_DIR" && PATH="$TMPBIN:$PATH" mise run -q "$@"
+}
+
+write_fake_browser() {
+  local body="$1"
+  cat > "$TMPBIN/browser" <<EOF
+#!/usr/bin/env bash
+$body
+EOF
+  chmod +x "$TMPBIN/browser"
+}
+
+@test "github:token:list passes TSV separator to gum table" {
+  write_fake_browser 'printf "%s\n" "login diagnostic" "TOKENS_JSON:[{\"id\":\"123\",\"name\":\"ikma\",\"status\":[\"Expired\"]}]"'
+  cat > "$TMPBIN/gum" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" > "$BATS_TEST_TMPDIR/gum-args"
+cat > "$BATS_TEST_TMPDIR/gum-stdin"
+printf 'gum output\n'
+EOF
+  chmod +x "$TMPBIN/gum"
+
+  run --separate-stderr websites github:token:list
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "gum output" ]
+  grep -q -- '--separator' "$BATS_TEST_TMPDIR/gum-args"
+  grep -q $'123\tikma\tExpired' "$BATS_TEST_TMPDIR/gum-stdin"
+  [[ "$stderr" == *"login diagnostic"* ]]
+}
+
+@test "github:token:list --json emits only JSON on stdout" {
+  write_fake_browser 'printf "%s\n" "login diagnostic" "TOKENS_JSON:[{\"id\":\"123\",\"name\":\"ikma\",\"status\":[]}]"'
+
+  run --separate-stderr websites github:token:list --json
+
+  [ "$status" -eq 0 ]
+  [ "$(echo "$output" | jq -r '.[0].name')" = "ikma" ]
+  [[ "$stderr" == *"login diagnostic"* ]]
+}
+
+@test "github:token:rotate reports explicit extraction error when TOKEN line is missing" {
+  write_fake_browser 'printf "%s\n" "browser succeeded but emitted no token"'
+
+  run --separate-stderr websites github:token:rotate ikma
+
+  [ "$status" -ne 0 ]
+  [[ "$stderr" == *"ERROR: Could not extract token from script output"* ]]
+}

--- a/test/setup_suite.bash
+++ b/test/setup_suite.bash
@@ -1,0 +1,4 @@
+setup_suite() {
+  export REPO_DIR="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+  eval "$(cd "$REPO_DIR" && mise env)"
+}


### PR DESCRIPTION
## Summary

- fix GitHub login automation to detect device verification by visible OTP input, not just old URL patterns
- add `websites github:token:list` with gum table output and `--json`
- make token rotation find classic PATs by exact visible token name instead of substring `:has-text(...)`
- parse token expiration headers without sed and use Node date parsing for cross-platform expiry checks
- add task-level BATS coverage for the GitHub token task wrappers via fake `browser`/`gum` shims
- add a standard `mise run test` task

## Verification

- `bats test/`
- `mise run test`
- `mise run github:api:token-check`
- live-smoked token rotation for `ikma`, `zeke`, and `baby-joel`; each new PAT was stored via `shimmer github:token:store` and verified with `gh api user` + token-check

## Notes

This came from rotating Ikma's expired PAT. The old rotation flow was falsely reporting a successful login while GitHub was waiting on device verification, which made the token page appear empty.
