### PR TITLE
Handle Buttondown Bun task errors cleanly

### DIFF
--- a/.mise/tasks/buttondown/api/newsletters
+++ b/.mise/tasks/buttondown/api/newsletters
@@ -3,5 +3,10 @@
 
 import { runResource } from '../../../../scripts/buttondown/api.mjs';
 
-const output = await runResource('newsletters', {});
-console.log(JSON.stringify(output, null, 2));
+try {
+  const output = await runResource('newsletters', {});
+  console.log(JSON.stringify(output, null, 2));
+} catch (error) {
+  console.error(`ERROR: ${error instanceof Error ? error.message : String(error)}`);
+  process.exit(1);
+}

--- a/.mise/tasks/buttondown/api/subscribers
+++ b/.mise/tasks/buttondown/api/subscribers
@@ -38,5 +38,10 @@ const options: SubscriberOptions = {
   referrerUrl: optionalEnv('usage_referrer_url'),
 };
 
-const output = await runResource('subscribers', options);
-console.log(JSON.stringify(output, null, 2));
+try {
+  const output = await runResource('subscribers', options);
+  console.log(JSON.stringify(output, null, 2));
+} catch (error) {
+  console.error(`ERROR: ${error instanceof Error ? error.message : String(error)}`);
+  process.exit(1);
+}

--- a/.mise/tasks/buttondown/api/tags
+++ b/.mise/tasks/buttondown/api/tags
@@ -4,7 +4,12 @@
 
 import { runResource } from '../../../../scripts/buttondown/api.mjs';
 
-const output = await runResource('tags', {
-  pageSize: process.env.usage_page_size ?? '1000',
-});
-console.log(JSON.stringify(output, null, 2));
+try {
+  const output = await runResource('tags', {
+    pageSize: process.env.usage_page_size ?? '1000',
+  });
+  console.log(JSON.stringify(output, null, 2));
+} catch (error) {
+  console.error(`ERROR: ${error instanceof Error ? error.message : String(error)}`);
+  process.exit(1);
+}


### PR DESCRIPTION
Fix-it PR for KnickKnackLabs/websites#28 re-review.

The Bun task wrappers currently let rejected `runResource(...)` calls fall through to Bun's default exception reporter, which prints a source snippet and stack trace for normal operator errors like a missing `BUTTONDOWN_API_KEY`.

This restores the previous task behavior: print `ERROR: <message>` and exit non-zero.

Validation run locally:

- `mise run -q buttondown:api:newsletters` without `BUTTONDOWN_API_KEY` prints a concise error and exits 1
- `bun build .mise/tasks/buttondown/api/newsletters .mise/tasks/buttondown/api/tags .mise/tasks/buttondown/api/subscribers --target=bun --outdir /tmp/websites-buttondown-task-check-fix`
- `mise run test buttondown-api` — 6/6 passing
- `mise run test` — 42/42 passing
