### PR TITLE
Handle GitHub post-2FA token gate

### DIFF
--- a/scripts/github/login.mjs
+++ b/scripts/github/login.mjs
@@ -65,6 +65,7 @@ async function submitOtpCode(page, otpInput, code) {
 // Throws on failure.
 export async function login(page, { agent, username, password }) {
   console.log(`Logging in as ${username}...`);
+  let loginTotpCode = null;
 
   await page.goto('https://github.com/login');
   await page.waitForLoadState('domcontentloaded');
@@ -89,7 +90,8 @@ export async function login(page, { agent, username, password }) {
 
     if (challengeType === 'totp') {
       console.log('Two-factor authentication required. Generating TOTP code...');
-      await submitOtpCode(page, otpInput, resolveGitHubTotpCode(agent));
+      loginTotpCode = resolveGitHubTotpCode(agent);
+      await submitOtpCode(page, otpInput, loginTotpCode);
     } else {
       console.log('Device verification required. Polling email...');
 
@@ -120,4 +122,5 @@ export async function login(page, { agent, username, password }) {
   }
 
   console.log('Logged in successfully.');
+  return { loginTotpCode };
 }

--- a/scripts/github/login.mjs
+++ b/scripts/github/login.mjs
@@ -7,6 +7,7 @@
 //   import { login } from './login.mjs';
 //   await login(page, { agent: 'x1f9', username, password });
 
+import { execFileSync } from 'node:child_process';
 import { pollForVerificationCode } from './email-code.mjs';
 import { record } from '../record.mjs';
 
@@ -37,12 +38,24 @@ export function normalizeTotpCode(value) {
   return code;
 }
 
-export function resolveGitHubTotpCode(agent, { env = process.env } = {}) {
+export function resolveGitHubTotpCode(agent, { env = process.env, execFile = execFileSync } = {}) {
+  if (env.GITHUB_TOTP_COMMAND) {
+    try {
+      const output = execFile('bash', ['-lc', env.GITHUB_TOTP_COMMAND], {
+        encoding: 'utf8',
+        env,
+      });
+      return normalizeTotpCode(output);
+    } catch {
+      throw new Error(`GitHub two-factor authentication command failed for ${agent}.`);
+    }
+  }
+
   if (env.GITHUB_TOTP_CODE) {
     return normalizeTotpCode(env.GITHUB_TOTP_CODE);
   }
 
-  throw new Error(`GitHub two-factor authentication required for ${agent}; set GITHUB_TOTP_CODE to a current code.`);
+  throw new Error(`GitHub two-factor authentication required for ${agent}; set GITHUB_TOTP_CODE or GITHUB_TOTP_COMMAND to a current code source.`);
 }
 
 async function submitOtpCode(page, otpInput, code) {

--- a/scripts/github/sensitive-page-gate.mjs
+++ b/scripts/github/sensitive-page-gate.mjs
@@ -1,0 +1,109 @@
+// sensitive-page-gate.mjs — clear GitHub sensitive-page auth gates
+//
+// GitHub may show a one-time post-2FA verification interstitial after a
+// successful login when navigating to sensitive settings pages such as classic
+// PAT create/list/rotate. This helper handles that page state with an explicit
+// fresh-TOTP contract: if login just consumed a TOTP, the verification TOTP must
+// differ from it.
+
+import { normalizeTotpCode, resolveGitHubTotpCode } from './login.mjs';
+
+const POST_2FA_VERIFY_SELECTOR = [
+  'button:has-text("Verify 2FA now")',
+  'input[value*="Verify 2FA"]',
+].join(', ');
+
+const POST_2FA_OTP_SELECTOR = [
+  '#app_totp',
+  'input[name="app_otp"]',
+  '#otp',
+  'input[name="otp"]',
+  'input[autocomplete="one-time-code"]',
+].join(', ');
+
+const POST_2FA_SUBMIT_SELECTOR = [
+  'button:has-text("Verify")',
+  'button[type="submit"]',
+  'input[type="submit"]',
+].join(', ');
+
+function defaultSleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+export async function resolveFreshGitHubTotpCode({
+  agent,
+  totpResolver = resolveGitHubTotpCode,
+  previousCode = null,
+  timeoutMs = 65000,
+  pollMs = 1000,
+  sleep = defaultSleep,
+} = {}) {
+  const previous = previousCode ? normalizeTotpCode(previousCode) : null;
+  const started = Date.now();
+
+  while (true) {
+    const candidate = normalizeTotpCode(await totpResolver(agent));
+    if (!previous || candidate !== previous) {
+      return candidate;
+    }
+
+    if (Date.now() - started >= timeoutMs) {
+      throw new Error('Fresh GitHub TOTP code was not available before timeout; refusing to replay the login-consumed code.');
+    }
+
+    await sleep(Math.min(pollMs, Math.max(0, timeoutMs - (Date.now() - started))));
+  }
+}
+
+export async function handlePost2faVerificationInterstitial(page, {
+  agent,
+  totpResolver = resolveGitHubTotpCode,
+  loginTotpCode = null,
+  freshTotpTimeoutMs = 65000,
+  freshTotpPollMs = 1000,
+  sleep = defaultSleep,
+} = {}) {
+  const verifyButton = page.locator(POST_2FA_VERIFY_SELECTOR).first();
+  const visible = await verifyButton.isVisible({ timeout: 1500 }).catch(() => false);
+  if (!visible) {
+    return false;
+  }
+
+  const title = await page.title?.().catch(() => '') || '';
+  console.error(`GitHub post-2FA verification interstitial detected${title ? ` (${title})` : ''}; verifying with a fresh TOTP.`);
+
+  await verifyButton.click();
+  await page.waitForLoadState('domcontentloaded').catch(() => {});
+
+  const otpInput = page.locator(POST_2FA_OTP_SELECTOR).first();
+  await otpInput.waitFor({ state: 'visible', timeout: 8000 });
+
+  const code = await resolveFreshGitHubTotpCode({
+    agent,
+    totpResolver,
+    previousCode: loginTotpCode,
+    timeoutMs: freshTotpTimeoutMs,
+    pollMs: freshTotpPollMs,
+    sleep,
+  });
+  await otpInput.fill(code);
+
+  const submit = page.locator(POST_2FA_SUBMIT_SELECTOR).first();
+  await submit.click();
+  await page.waitForLoadState('domcontentloaded').catch(() => {});
+  return true;
+}
+
+export async function openGitHubSensitivePage(page, url, options = {}) {
+  await page.goto(url);
+  await page.waitForLoadState('domcontentloaded');
+
+  const cleared = await handlePost2faVerificationInterstitial(page, options);
+  if (cleared) {
+    await page.goto(url);
+    await page.waitForLoadState('domcontentloaded');
+  }
+
+  return { clearedPost2faVerification: cleared };
+}

--- a/scripts/github/token-create.mjs
+++ b/scripts/github/token-create.mjs
@@ -6,7 +6,8 @@
 //
 // Usage: browser run --headed ./scripts/github/token-create.mjs -- <token-name> [login-id]
 
-import { login } from './login.mjs';
+import { login, resolveGitHubTotpCode } from './login.mjs';
+import { openGitHubSensitivePage } from './sensitive-page-gate.mjs';
 import { record } from '../record.mjs';
 import { isGitHubToken, parseTokenFromText } from './tokens.mjs';
 
@@ -80,10 +81,13 @@ export default async function({ page, args }) {
     process.exit(1);
   }
 
-  await login(page, { agent: loginId, username, password });
+  const loginResult = await login(page, { agent: loginId, username, password });
 
-  await page.goto(tokenCreationUrl(tokenName));
-  await page.waitForLoadState('domcontentloaded');
+  await openGitHubSensitivePage(page, tokenCreationUrl(tokenName), {
+    agent: loginId,
+    loginTotpCode: loginResult.loginTotpCode,
+    totpResolver: resolveGitHubTotpCode,
+  });
   record(`token-create-page-${loginId}.html`, await page.content());
 
   const loginFormStillVisible = await page.locator('input[name="login"], input[name="password"]').first()

--- a/scripts/github/token-list.mjs
+++ b/scripts/github/token-list.mjs
@@ -6,7 +6,8 @@
 //
 // Usage: browser run ./scripts/github/token-list.mjs -- <login-id>
 
-import { login } from './login.mjs';
+import { login, resolveGitHubTotpCode } from './login.mjs';
+import { openGitHubSensitivePage } from './sensitive-page-gate.mjs';
 import { record } from '../record.mjs';
 import { listClassicTokens } from './tokens.mjs';
 
@@ -20,10 +21,13 @@ export default async function({ page, args }) {
     process.exit(1);
   }
 
-  await login(page, { agent: loginId, username, password });
+  const loginResult = await login(page, { agent: loginId, username, password });
 
-  await page.goto('https://github.com/settings/tokens');
-  await page.waitForLoadState('domcontentloaded');
+  await openGitHubSensitivePage(page, 'https://github.com/settings/tokens', {
+    agent: loginId,
+    loginTotpCode: loginResult.loginTotpCode,
+    totpResolver: resolveGitHubTotpCode,
+  });
   record(`tokens-page-${loginId}.html`, await page.content());
 
   const loginFormStillVisible = await page.locator('input[name="login"], input[name="password"]').first()

--- a/scripts/github/token-rotate.mjs
+++ b/scripts/github/token-rotate.mjs
@@ -6,7 +6,8 @@
 //
 // Usage: browser run --headed ./scripts/github/token-rotate.mjs -- <token-name> [login-id]
 
-import { login } from './login.mjs';
+import { login, resolveGitHubTotpCode } from './login.mjs';
+import { openGitHubSensitivePage } from './sensitive-page-gate.mjs';
 import { record } from '../record.mjs';
 import {
   findClassicTokenByName,
@@ -37,11 +38,15 @@ export default async function({ page, args }) {
   }
 
   // --- Login ---
-  await login(page, { agent: loginId, username, password });
+  const loginResult = await login(page, { agent: loginId, username, password });
+  const sensitivePageOptions = {
+    agent: loginId,
+    loginTotpCode: loginResult.loginTotpCode,
+    totpResolver: resolveGitHubTotpCode,
+  };
 
   // --- Navigate to classic tokens page ---
-  await page.goto('https://github.com/settings/tokens');
-  await page.waitForLoadState('domcontentloaded');
+  await openGitHubSensitivePage(page, 'https://github.com/settings/tokens', sensitivePageOptions);
   record(`tokens-page-${loginId}.html`, await page.content());
 
   const loginFormStillVisible = await page.locator('input[name="login"], input[name="password"]').first()
@@ -73,8 +78,7 @@ export default async function({ page, args }) {
   console.log(`Found token "${tokenName}" (ID: ${tokenId}). Regenerating...`);
 
   // --- Regenerate ---
-  await page.goto(`https://github.com/settings/tokens/${tokenId}/regenerate`);
-  await page.waitForLoadState('domcontentloaded');
+  await openGitHubSensitivePage(page, `https://github.com/settings/tokens/${tokenId}/regenerate`, sensitivePageOptions);
   record(`regenerate-page-${loginId}.html`, await page.content());
 
   // Set expiration to 30 days

--- a/test/github-parsing.bats
+++ b/test/github-parsing.bats
@@ -136,6 +136,44 @@ run_js() {
   [ "$output" = "123456" ]
 }
 
+@test "resolveGitHubTotpCode: reruns command-backed resolver on each call" {
+  run_js "
+    import { resolveGitHubTotpCode } from '$SCRIPTS_DIR/login.mjs';
+    let calls = 0;
+    const execFile = (file, args, options) => {
+      calls += 1;
+      if (file !== 'bash') throw new Error('wrong file');
+      if (args[0] !== '-lc') throw new Error('wrong shell flag');
+      if (args[1] !== 'totp-command') throw new Error('wrong command');
+      if (options.encoding !== 'utf8') throw new Error('wrong encoding');
+      return calls === 1 ? '111111\n' : '222222\n';
+    };
+    const env = { GITHUB_TOTP_COMMAND: 'totp-command', GITHUB_TOTP_CODE: '999999' };
+    const first = resolveGitHubTotpCode('zeke', { env, execFile });
+    const second = resolveGitHubTotpCode('zeke', { env, execFile });
+    console.log(JSON.stringify({ first, second, calls }));
+  "
+  [ "$output" = '{"first":"111111","second":"222222","calls":2}' ]
+}
+
+@test "resolveGitHubTotpCode: sanitizes command failures" {
+  run_js "
+    import { resolveGitHubTotpCode } from '$SCRIPTS_DIR/login.mjs';
+    try {
+      resolveGitHubTotpCode('zeke', {
+        env: { GITHUB_TOTP_COMMAND: 'secret totp command' },
+        execFile: () => { throw new Error('stderr leaked 123456'); },
+      });
+      console.log('no error');
+    } catch (error) {
+      console.log(error.message);
+    }
+  "
+  [[ "$output" == *"command failed for zeke"* ]]
+  [[ "$output" != *"secret totp command"* ]]
+  [[ "$output" != *"123456"* ]]
+}
+
 @test "resolveGitHubTotpCode: requires caller-injected code" {
   run_js "
     import { resolveGitHubTotpCode } from '$SCRIPTS_DIR/login.mjs';
@@ -146,7 +184,7 @@ run_js() {
       console.log(error.message);
     }
   "
-  [[ "$output" == *"set GITHUB_TOTP_CODE"* ]]
+  [[ "$output" == *"set GITHUB_TOTP_CODE or GITHUB_TOTP_COMMAND"* ]]
   [[ "$output" != *"secrets"* ]]
 }
 

--- a/test/github-sensitive-page-gate.bats
+++ b/test/github-sensitive-page-gate.bats
@@ -98,6 +98,32 @@ EOF
   [[ "$output" != *"123456"* ]]
 }
 
+@test "fresh TOTP resolver can use command-backed production resolver for new code" {
+  run_js_file <<EOF
+import { resolveGitHubTotpCode } from '$SCRIPTS_DIR/login.mjs';
+import { resolveFreshGitHubTotpCode } from '$SCRIPTS_DIR/sensitive-page-gate.mjs';
+
+let calls = 0;
+const env = { GITHUB_TOTP_COMMAND: 'totp-command' };
+const execFile = () => {
+  calls += 1;
+  return calls === 1 ? '123456\n' : '654321\n';
+};
+const code = await resolveFreshGitHubTotpCode({
+  agent: 'c0da',
+  previousCode: '123456',
+  timeoutMs: 5000,
+  pollMs: 1,
+  sleep: async () => {},
+  totpResolver: agent => resolveGitHubTotpCode(agent, { env, execFile }),
+});
+console.log(JSON.stringify({ code, calls }));
+EOF
+
+  [ "$status" -eq 0 ]
+  [ "$output" = '{"code":"654321","calls":2}' ]
+}
+
 @test "openGitHubSensitivePage revisits target after clearing interstitial" {
   run_js_file <<EOF
 import { openGitHubSensitivePage } from '$SCRIPTS_DIR/sensitive-page-gate.mjs';

--- a/test/github-sensitive-page-gate.bats
+++ b/test/github-sensitive-page-gate.bats
@@ -1,0 +1,130 @@
+#!/usr/bin/env bats
+
+bats_require_minimum_version 1.5.0
+
+SCRIPTS_DIR="$BATS_TEST_DIRNAME/../scripts/github"
+
+run_js_file() {
+  local file="$BATS_TEST_TMPDIR/test.mjs"
+  cat > "$file"
+  run --separate-stderr node "$file"
+}
+
+@test "post-2FA gate returns false when no interstitial is visible" {
+  run_js_file <<EOF
+import { handlePost2faVerificationInterstitial } from '$SCRIPTS_DIR/sensitive-page-gate.mjs';
+
+let clicked = false;
+const page = {
+  locator() {
+    return { first: () => ({ isVisible: async () => false, click: async () => { clicked = true; } }) };
+  },
+};
+
+const handled = await handlePost2faVerificationInterstitial(page, {
+  agent: 'ikma',
+  totpResolver: async () => '111111',
+});
+console.log(JSON.stringify({ handled, clicked }));
+EOF
+
+  [ "$status" -eq 0 ]
+  [ "$output" = '{"handled":false,"clicked":false}' ]
+}
+
+@test "post-2FA gate submits a fresh TOTP through app_otp and never clicks skip" {
+  run_js_file <<EOF
+import { handlePost2faVerificationInterstitial } from '$SCRIPTS_DIR/sensitive-page-gate.mjs';
+
+const calls = [];
+let filled = null;
+let usedAppOtpSelector = false;
+let resolverCalls = 0;
+const page = {
+  title: async () => 'Verify two-factor authentication',
+  waitForLoadState: async state => calls.push(['wait', state]),
+  locator(selector) {
+    if (selector.includes('skip 2FA verification')) throw new Error('skip selector must not be used');
+    return { first: () => ({
+      isVisible: async () => selector.includes('Verify 2FA now'),
+      click: async () => calls.push(['click', selector]),
+      waitFor: async options => calls.push(['waitFor', selector, options.state]),
+      fill: async value => { filled = value; usedAppOtpSelector = selector.includes('input[name="app_otp"]'); calls.push(['fill', selector]); },
+    }) };
+  },
+};
+
+const handled = await handlePost2faVerificationInterstitial(page, {
+  agent: 'ikma',
+  loginTotpCode: '111111',
+  freshTotpTimeoutMs: 5000,
+  freshTotpPollMs: 1,
+  sleep: async () => calls.push(['sleep']),
+  totpResolver: async agent => {
+    resolverCalls += 1;
+    calls.push(['resolve', agent]);
+    return resolverCalls === 1 ? '111111' : '222222';
+  },
+});
+
+console.log(JSON.stringify({ handled, filled, usedAppOtpSelector, resolverCalls, slept: calls.some(call => call[0] === 'sleep') }));
+EOF
+
+  [ "$status" -eq 0 ]
+  [ "$output" = '{"handled":true,"filled":"222222","usedAppOtpSelector":true,"resolverCalls":2,"slept":true}' ]
+}
+
+@test "fresh TOTP resolver refuses to replay login-consumed code with sanitized error" {
+  run_js_file <<EOF
+import { resolveFreshGitHubTotpCode } from '$SCRIPTS_DIR/sensitive-page-gate.mjs';
+
+try {
+  await resolveFreshGitHubTotpCode({
+    agent: 'c0da',
+    previousCode: '123456',
+    timeoutMs: 0,
+    pollMs: 0,
+    sleep: async () => {},
+    totpResolver: async () => '123456',
+  });
+  console.log('no error');
+} catch (error) {
+  console.log(error.message);
+}
+EOF
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"refusing to replay"* ]]
+  [[ "$output" != *"123456"* ]]
+}
+
+@test "openGitHubSensitivePage revisits target after clearing interstitial" {
+  run_js_file <<EOF
+import { openGitHubSensitivePage } from '$SCRIPTS_DIR/sensitive-page-gate.mjs';
+
+const gotos = [];
+let verifyVisible = true;
+const page = {
+  title: async () => 'Verify two-factor authentication',
+  goto: async url => gotos.push(url),
+  waitForLoadState: async () => {},
+  locator(selector) {
+    return { first: () => ({
+      isVisible: async () => selector.includes('Verify 2FA now') && verifyVisible,
+      click: async () => { if (selector.includes('Verify')) verifyVisible = false; },
+      waitFor: async () => {},
+      fill: async () => {},
+    }) };
+  },
+};
+
+const result = await openGitHubSensitivePage(page, 'https://github.com/settings/tokens/new?description=ikma', {
+  agent: 'ikma',
+  totpResolver: async () => '333333',
+});
+console.log(JSON.stringify({ gotos, result }));
+EOF
+
+  [ "$status" -eq 0 ]
+  [ "$output" = '{"gotos":["https://github.com/settings/tokens/new?description=ikma","https://github.com/settings/tokens/new?description=ikma"],"result":{"clearedPost2faVerification":true}}' ]
+}

--- a/test/setup_suite.bash
+++ b/test/setup_suite.bash
@@ -1,4 +1,18 @@
 setup_suite() {
   export REPO_DIR="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
   eval "$(cd "$REPO_DIR" && mise env)"
+
+  # mise's generated PATH points at bats-core/bin, while bats invokes helpers
+  # from libexec/bats-core by bare command name after setup_suite runs.
+  # Preserve that helper path so setup_suite does not make the runner lose
+  # bats-exec-file for the rest of the suite.
+  local bats_bin bats_root bats_libexec
+  bats_bin="$(command -v bats || true)"
+  if [ -n "$bats_bin" ]; then
+    bats_root="$(cd "$(dirname "$bats_bin")/.." && pwd)"
+    bats_libexec="$bats_root/libexec/bats-core"
+    if [ -x "$bats_libexec/bats-exec-file" ]; then
+      export PATH="$bats_libexec:$PATH"
+    fi
+  fi
 }


### PR DESCRIPTION
## Summary

- Add a reusable GitHub sensitive-page gate for the post-2FA verification interstitial.
- Thread the login-consumed TOTP into token create/list/rotate so the gate waits for a different fresh TOTP before submitting.
- Use the gate after navigating to token settings pages, including rotate's list and regenerate pages.
- Add fixture-style unit coverage with mocked pages/resolvers; no live GitHub credentials are used and no tokens are created or rotated.

Closes #32.

## Validation

- `mise run test github-sensitive-page-gate`
- `mise run test`
- `git diff --check`

## Safety

Live credential mutation is intentionally avoided in this PR path: tests use mocked browser page objects and mocked TOTP resolvers only. I did not run the token create/rotate tasks against GitHub, did not use real credentials, and did not create/rotate any real tokens.
