### PR TITLE
Harden GitHub token capture and diagnostics

### DIFF
--- a/.mise/tasks/github/token/diagnose
+++ b/.mise/tasks/github/token/diagnose
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+#MISE description="Print non-mutating safe diagnostics for GitHub token pages"
+#USAGE arg "[mode]" default="create" help="Page to inspect: create, list, or regenerate"
+#USAGE arg "[name]" default="diagnostic-token" help="Token name for create defaults or regenerate lookup"
+#USAGE flag "--login-id <id>" default="" help="Identity used for email verification polling/TOTP lookup"
+
+set -euo pipefail
+
+MODE="${usage_mode:-create}"
+TOKEN_NAME="${usage_name:-diagnostic-token}"
+LOGIN_ID="${usage_login_id:-${GIT_AUTHOR_NAME:-$TOKEN_NAME}}"
+PROJECT_DIR="${MISE_CONFIG_ROOT:?MISE_CONFIG_ROOT not set}"
+
+if [ -z "${GITHUB_USERNAME:-}" ] || [ -z "${GITHUB_PASSWORD:-}" ]; then
+  echo "ERROR: GITHUB_USERNAME and GITHUB_PASSWORD env vars required." >&2
+  exit 1
+fi
+
+browser run "$PROJECT_DIR/scripts/github/token-diagnose.mjs" -- "$MODE" "$TOKEN_NAME" "$LOGIN_ID"

--- a/scripts/github/page-diagnostics.mjs
+++ b/scripts/github/page-diagnostics.mjs
@@ -1,0 +1,141 @@
+// page-diagnostics.mjs — Structure-first safe diagnostics for GitHub automation pages.
+
+const GITHUB_TOKEN_RE = /(?:gh[pousr]_[A-Za-z0-9_]+|github_pat_[A-Za-z0-9_]+)/g;
+const EMAIL_RE = /[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi;
+const RECOVERY_CODE_RE = /\b[a-z0-9]{5}-[a-z0-9]{5}\b/gi;
+const CONTEXTUAL_CODE_RE = /\b(?:otp|totp|verification|authentication|code)\D{0,24}(\d{6,8})\b/gi;
+
+function compact(text) {
+  return String(text || '').replace(/\s+/g, ' ').trim();
+}
+
+export function redactSensitiveText(text) {
+  return compact(text)
+    .replace(GITHUB_TOKEN_RE, '[REDACTED_GITHUB_TOKEN]')
+    .replace(EMAIL_RE, '[REDACTED_EMAIL]')
+    .replace(RECOVERY_CODE_RE, '[REDACTED_RECOVERY_CODE]')
+    .replace(CONTEXTUAL_CODE_RE, (match, code) => match.replace(code, '[REDACTED_CODE]'));
+}
+
+export function safeUrl(url) {
+  try {
+    const parsed = new URL(String(url || ''));
+    parsed.username = '';
+    parsed.password = '';
+    if (parsed.search) parsed.search = '?[query]';
+    if (parsed.hash) parsed.hash = '#[fragment]';
+    return redactSensitiveText(parsed.toString());
+  } catch {
+    return redactSensitiveText(url);
+  }
+}
+
+function limitedStrings(values, limit = 30) {
+  return (values || [])
+    .map(redactSensitiveText)
+    .filter(Boolean)
+    .slice(0, limit);
+}
+
+function normalizeControl(control) {
+  const tag = redactSensitiveText(control?.tag || '').toLowerCase();
+  const type = redactSensitiveText(control?.type || '').toLowerCase();
+  const valuePresent = Boolean(control?.valuePresent || control?.value);
+  const normalized = {
+    tag,
+    type,
+    id: redactSensitiveText(control?.id || ''),
+    name: redactSensitiveText(control?.name || ''),
+    labels: limitedStrings(control?.labels || [], 4),
+    disabled: Boolean(control?.disabled),
+  };
+
+  if (valuePresent) normalized.value = '[present]';
+  if ((tag === 'button' || ['button', 'submit', 'reset'].includes(type)) && control?.text) {
+    normalized.text = redactSensitiveText(control.text).slice(0, 160);
+  }
+  return normalized;
+}
+
+export function sanitizePageFacts(rawFacts = {}) {
+  return {
+    url: safeUrl(rawFacts.url || ''),
+    title: redactSensitiveText(rawFacts.title || ''),
+    headings: limitedStrings(rawFacts.headings || [], 30),
+    alerts: limitedStrings(rawFacts.alerts || [], 30),
+    buttons: limitedStrings(rawFacts.buttons || [], 80),
+    controls: (rawFacts.controls || []).slice(0, 80).map(normalizeControl),
+  };
+}
+
+async function visibleTexts(page, selector, limit = 30) {
+  try {
+    return await page.locator(selector).evaluateAll((elements, max) => elements
+      .filter((el) => {
+        const style = window.getComputedStyle(el);
+        const rect = el.getBoundingClientRect();
+        return style.visibility !== 'hidden' && style.display !== 'none' && rect.width > 0 && rect.height > 0;
+      })
+      .map((el) => el.innerText || el.textContent || '')
+      .filter(Boolean)
+      .slice(0, max), limit);
+  } catch {
+    try {
+      return (await page.locator(selector).allTextContents()).slice(0, limit);
+    } catch {
+      return [];
+    }
+  }
+}
+
+export async function sanitizedPageFacts(page) {
+  const [title, headings, alerts, buttons, controls] = await Promise.all([
+    page.title().catch(() => ''),
+    visibleTexts(page, 'h1,h2,h3', 30),
+    visibleTexts(page, '[role="alert"], .flash, .flash-error, .flash-warn, .flash-notice', 30),
+    visibleTexts(page, 'button, input[type="button"], input[type="submit"], a.btn', 80),
+    page.evaluate(() => Array.from(document.querySelectorAll('input, button, select, textarea'))
+      .filter((el) => {
+        const style = window.getComputedStyle(el);
+        const rect = el.getBoundingClientRect();
+        return style.visibility !== 'hidden' && style.display !== 'none' && rect.width > 0 && rect.height > 0;
+      })
+      .slice(0, 80)
+      .map((el) => {
+        const tag = el.tagName.toLowerCase();
+        const type = (el.getAttribute('type') || '').toLowerCase();
+        const labels = Array.from(el.labels || []).map(label => label.innerText || label.textContent || '');
+        const value = el.getAttribute('value') || el.value || '';
+        return {
+          tag,
+          type,
+          id: el.id || '',
+          name: el.getAttribute('name') || '',
+          labels,
+          valuePresent: Boolean(value),
+          text: tag === 'button' || ['button', 'submit', 'reset'].includes(type)
+            ? (el.innerText || el.textContent || value || '')
+            : '',
+          disabled: Boolean(el.disabled),
+        };
+      })).catch(() => []),
+  ]);
+
+  return sanitizePageFacts({
+    url: page.url(),
+    title,
+    headings,
+    alerts,
+    buttons,
+    controls,
+  });
+}
+
+export function formatPageFacts(facts) {
+  return JSON.stringify(sanitizePageFacts(facts), null, 2);
+}
+
+export async function logSafePageFacts(page, label = 'Safe page facts') {
+  console.error(`${label}:`);
+  console.error(formatPageFacts(await sanitizedPageFacts(page)));
+}

--- a/scripts/github/token-capture.mjs
+++ b/scripts/github/token-capture.mjs
@@ -1,0 +1,82 @@
+// token-capture.mjs — Shared GitHub PAT capture after create/regenerate pages.
+
+import { GITHUB_TOKEN_PATTERN, isGitHubToken, parseTokenFromText } from './tokens.mjs';
+
+export const TOKEN_DISPLAY_SELECTOR = [
+  'input#new-oauth-token',
+  '[data-clipboard-text^="ghp_"]',
+  '[data-clipboard-text^="gho_"]',
+  '[data-clipboard-text^="ghu_"]',
+  '[data-clipboard-text^="ghs_"]',
+  '[data-clipboard-text^="ghr_"]',
+  '[data-clipboard-text^="github_pat_"]',
+].join(', ');
+
+const TOKEN_CAPTURE_SELECTORS = [
+  'input#new-oauth-token',
+  '[data-clipboard-text]',
+  'clipboard-copy',
+  'input[value*="ghp_"], input[value*="gho_"], input[value*="ghu_"], input[value*="ghs_"], input[value*="ghr_"], input[value*="github_pat_"]',
+  'textarea',
+  'code',
+  'pre',
+  '.token',
+  '.oauth-token',
+];
+
+async function tokenFromElement(element) {
+  const candidates = [];
+  for (const attr of ['value', 'data-clipboard-text', 'aria-label', 'title']) {
+    candidates.push(await element.getAttribute(attr).catch(() => null));
+  }
+  candidates.push(await element.textContent().catch(() => null));
+
+  for (const candidate of candidates) {
+    const token = parseTokenFromText(candidate || '');
+    if (isGitHubToken(token)) return token;
+  }
+  return null;
+}
+
+export async function captureGitHubTokenFromPage(page) {
+  for (const selector of TOKEN_CAPTURE_SELECTORS) {
+    const loc = page.locator(selector);
+    const count = await loc.count().catch(() => 0);
+    for (let i = 0; i < count; i++) {
+      const token = await tokenFromElement(loc.nth(i));
+      if (token) return token;
+    }
+  }
+
+  // Last resort: inspect DOM text and attributes in the browser context, but
+  // return only the token value. Never return/log the matching candidate or HTML.
+  const token = await page.evaluate((patternSource) => {
+    const re = new RegExp(patternSource);
+    const candidates = [document.body?.innerText || '', document.documentElement?.outerHTML || ''];
+    for (const el of document.querySelectorAll('*')) {
+      for (const attr of el.getAttributeNames()) candidates.push(el.getAttribute(attr) || '');
+    }
+    for (const candidate of candidates) {
+      const match = String(candidate || '').match(re);
+      if (match) return match[1];
+    }
+    return null;
+  }, GITHUB_TOKEN_PATTERN.source).catch(() => null);
+
+  return isGitHubToken(token) ? token : null;
+}
+
+export async function waitForGitHubToken(page, { timeoutMs = 15000, intervalMs = 500 } = {}) {
+  const deadline = Date.now() + timeoutMs;
+  do {
+    const token = await captureGitHubTokenFromPage(page);
+    if (token) return token;
+    if (typeof page.waitForTimeout === 'function') {
+      await page.waitForTimeout(intervalMs).catch(() => new Promise(resolve => setTimeout(resolve, intervalMs)));
+    } else {
+      await new Promise(resolve => setTimeout(resolve, intervalMs));
+    }
+  } while (Date.now() < deadline);
+
+  return captureGitHubTokenFromPage(page);
+}

--- a/scripts/github/token-create.mjs
+++ b/scripts/github/token-create.mjs
@@ -8,7 +8,9 @@
 
 import { login } from './login.mjs';
 import { record } from '../record.mjs';
-import { isGitHubToken, parseTokenFromText } from './tokens.mjs';
+import { captureGitHubTokenFromPage, TOKEN_DISPLAY_SELECTOR, waitForGitHubToken } from './token-capture.mjs';
+import { logSafePageFacts } from './page-diagnostics.mjs';
+import { isGitHubToken } from './tokens.mjs';
 
 const FULL_ACCESS_SCOPES = [
   'repo',
@@ -46,22 +48,7 @@ async function fillIfVisible(locator, value) {
   return false;
 }
 
-async function captureToken(page) {
-  const tokenInput = page.locator('input#new-oauth-token');
-  if (await tokenInput.isVisible({ timeout: 3000 }).catch(() => false)) {
-    const value = await tokenInput.getAttribute('value');
-    if (value) return value;
-  }
-
-  const clipboardEl = page.locator('[data-clipboard-text^="ghp_"], [data-clipboard-text^="github_pat_"]').first();
-  if (await clipboardEl.isVisible({ timeout: 3000 }).catch(() => false)) {
-    const value = await clipboardEl.getAttribute('data-clipboard-text');
-    if (value) return value;
-  }
-
-  const pageText = await page.textContent('body');
-  return parseTokenFromText(pageText || '');
-}
+const captureToken = captureGitHubTokenFromPage;
 
 export { FULL_ACCESS_SCOPES, tokenCreationUrl, captureToken };
 
@@ -91,6 +78,7 @@ export default async function({ page, args }) {
     .catch(() => false);
   if (loginFormStillVisible) {
     console.error(`Not authenticated after login; redirected to ${page.url()}`);
+    await logSafePageFacts(page, 'Safe page facts after failed authentication');
     process.exit(1);
   }
 
@@ -114,20 +102,27 @@ export default async function({ page, args }) {
   }
 
   const createButton = page.locator('button:has-text("Generate token"), input[value*="Generate token"]').first();
-  await createButton.waitFor({ state: 'visible', timeout: 5000 });
+  try {
+    await createButton.waitFor({ state: 'visible', timeout: 5000 });
+  } catch (error) {
+    console.error('Could not find visible Generate token button.');
+    await logSafePageFacts(page, 'Safe page facts for missing create button');
+    throw error;
+  }
   await createButton.click();
 
   await page.waitForLoadState('domcontentloaded');
-  const tokenDisplayLocator = page.locator('input#new-oauth-token, [data-clipboard-text^="ghp_"], [data-clipboard-text^="github_pat_"]').first();
+  const tokenDisplayLocator = page.locator(TOKEN_DISPLAY_SELECTOR).first();
   await tokenDisplayLocator.waitFor({ state: 'visible', timeout: 15000 }).catch(() => {
     console.error('Warning: token display element not found within timeout, will try fallback methods.');
   });
   record(`token-created-page-${loginId}.html`, await page.content());
 
-  const newToken = await captureToken(page);
+  const newToken = await waitForGitHubToken(page, { timeoutMs: 3000 });
   if (!isGitHubToken(newToken)) {
     console.error('Could not capture new token from page.');
     console.error('The token may have been created — check the browser window.');
+    await logSafePageFacts(page, 'Safe page facts after token capture failure');
     process.exit(1);
   }
 

--- a/scripts/github/token-diagnose.mjs
+++ b/scripts/github/token-diagnose.mjs
@@ -1,0 +1,45 @@
+// token-diagnose.mjs — Non-mutating safe page-shape diagnostics for GitHub PAT pages.
+//
+// Usage: browser run ./scripts/github/token-diagnose.mjs -- <create|list|regenerate> [token-name] [login-id]
+
+import { login } from './login.mjs';
+import { tokenCreationUrl } from './token-create.mjs';
+import { findClassicTokenByName, listClassicTokens } from './tokens.mjs';
+import { logSafePageFacts } from './page-diagnostics.mjs';
+
+export default async function({ page, args }) {
+  const mode = args[0] || 'create';
+  const tokenName = args[1] || process.env.WEBSITES_TOKEN_NAME || 'diagnostic-token';
+  const loginId = args[2] || process.env.WEBSITES_LOGIN_ID || tokenName;
+
+  const username = process.env.GITHUB_USERNAME;
+  const password = process.env.GITHUB_PASSWORD;
+  if (!username || !password) {
+    console.error('GITHUB_USERNAME and GITHUB_PASSWORD env vars required');
+    process.exit(1);
+  }
+
+  await login(page, { agent: loginId, username, password });
+
+  if (mode === 'create') {
+    await page.goto(tokenCreationUrl(tokenName));
+  } else if (mode === 'list') {
+    await page.goto('https://github.com/settings/tokens');
+  } else if (mode === 'regenerate') {
+    await page.goto('https://github.com/settings/tokens');
+    await page.waitForLoadState('domcontentloaded');
+    const token = findClassicTokenByName(await listClassicTokens(page), tokenName);
+    if (!token?.id) {
+      console.error(`Token named "${tokenName}" not found; printing list page diagnostics only.`);
+      await logSafePageFacts(page, 'Safe GitHub token page diagnostics');
+      return;
+    }
+    await page.goto(`https://github.com/settings/tokens/${token.id}/regenerate`);
+  } else {
+    console.error('Usage: mode must be one of create, list, regenerate');
+    process.exit(1);
+  }
+
+  await page.waitForLoadState('domcontentloaded');
+  await logSafePageFacts(page, 'Safe GitHub token page diagnostics');
+}

--- a/scripts/github/token-rotate.mjs
+++ b/scripts/github/token-rotate.mjs
@@ -8,6 +8,8 @@
 
 import { login } from './login.mjs';
 import { record } from '../record.mjs';
+import { logSafePageFacts } from './page-diagnostics.mjs';
+import { TOKEN_DISPLAY_SELECTOR, waitForGitHubToken } from './token-capture.mjs';
 import {
   findClassicTokenByName,
   isGitHubToken,
@@ -49,6 +51,7 @@ export default async function({ page, args }) {
     .catch(() => false);
   if (loginFormStillVisible) {
     console.error(`Not authenticated after login; redirected to ${page.url()}`);
+    await logSafePageFacts(page, 'Safe page facts after failed authentication');
     process.exit(1);
   }
 
@@ -61,6 +64,7 @@ export default async function({ page, args }) {
     for (const visibleToken of tokens) {
       console.error(`  - ${visibleToken.id}\t${visibleToken.name}`);
     }
+    await logSafePageFacts(page, 'Safe page facts for missing token');
     process.exit(1);
   }
 
@@ -92,43 +96,30 @@ export default async function({ page, args }) {
 
   // Click "Regenerate token"
   const regenerateBtn = page.locator('button:has-text("Regenerate token"), input[value*="Regenerate"]').first();
-  await regenerateBtn.waitFor({ state: 'visible', timeout: 5000 });
+  try {
+    await regenerateBtn.waitFor({ state: 'visible', timeout: 5000 });
+  } catch (error) {
+    console.error('Could not find visible Regenerate token button.');
+    await logSafePageFacts(page, 'Safe page facts for missing regenerate button');
+    throw error;
+  }
   await regenerateBtn.click();
 
   // Wait for the new token to appear (wait for the token display element instead of a fixed sleep)
   await page.waitForLoadState('domcontentloaded');
-  const tokenDisplayLocator = page.locator('input#new-oauth-token, [data-clipboard-text^="ghp_"], [data-clipboard-text^="github_pat_"]').first();
+  const tokenDisplayLocator = page.locator(TOKEN_DISPLAY_SELECTOR).first();
   await tokenDisplayLocator.waitFor({ state: 'visible', timeout: 15000 }).catch(() => {
     console.error('Warning: token display element not found within timeout, will try fallback methods.');
   });
   record(`regenerated-page-${loginId}.html`, await page.content());
 
   // --- Capture the new token ---
-  let newToken = null;
-
-  // Method 1: input#new-oauth-token (GitHub's token display input)
-  const tokenInput = page.locator('input#new-oauth-token');
-  if (await tokenInput.isVisible({ timeout: 3000 }).catch(() => false)) {
-    newToken = await tokenInput.getAttribute('value');
-  }
-
-  // Method 2: data-clipboard-text attribute (GitHub's copy button)
-  if (!newToken) {
-    const clipboardEl = page.locator('[data-clipboard-text^="ghp_"], [data-clipboard-text^="github_pat_"]').first();
-    if (await clipboardEl.isVisible({ timeout: 3000 }).catch(() => false)) {
-      newToken = await clipboardEl.getAttribute('data-clipboard-text');
-    }
-  }
-
-  // Method 3: search full page text
-  if (!newToken) {
-    const pageText = await page.textContent('body');
-    newToken = parseTokenFromText(pageText);
-  }
+  const newToken = await waitForGitHubToken(page, { timeoutMs: 3000 });
 
   if (!isGitHubToken(newToken)) {
     console.error('Could not capture new token from page.');
     console.error('The token may have been regenerated — check the browser window.');
+    await logSafePageFacts(page, 'Safe page facts after token capture failure');
     process.exit(1);
   }
 

--- a/test/github-token-helpers.bats
+++ b/test/github-token-helpers.bats
@@ -1,0 +1,94 @@
+#!/usr/bin/env bats
+
+SCRIPTS_DIR="$BATS_TEST_DIRNAME/../scripts/github"
+
+run_js() {
+  run node --input-type=module -e "$1"
+}
+
+@test "captureGitHubTokenFromPage captures input token value" {
+  run_js "
+    import { captureGitHubTokenFromPage } from '$SCRIPTS_DIR/token-capture.mjs';
+    const page = fakePage({ 'input#new-oauth-token': [{ value: 'ghp_inputToken_123' }] });
+    console.log(await captureGitHubTokenFromPage(page));
+
+    function fakePage(map) {
+      return { locator: selector => fakeLocator(map[selector] || []), evaluate: async () => null };
+    }
+    function fakeLocator(elements) {
+      return { count: async () => elements.length, nth: i => fakeElement(elements[i]) };
+    }
+    function fakeElement(attrs) {
+      return {
+        getAttribute: async name => attrs[name] || null,
+        textContent: async () => attrs.text || '',
+      };
+    }
+  "
+  [ "$output" = "ghp_inputToken_123" ]
+}
+
+@test "captureGitHubTokenFromPage captures data-clipboard-text token" {
+  run_js "
+    import { captureGitHubTokenFromPage } from '$SCRIPTS_DIR/token-capture.mjs';
+    const page = fakePage({ '[data-clipboard-text]': [{ 'data-clipboard-text': 'ghp_clipboardToken_123' }] });
+    console.log(await captureGitHubTokenFromPage(page));
+
+    function fakePage(map) { return { locator: selector => fakeLocator(map[selector] || []), evaluate: async () => null }; }
+    function fakeLocator(elements) { return { count: async () => elements.length, nth: i => fakeElement(elements[i]) }; }
+    function fakeElement(attrs) { return { getAttribute: async name => attrs[name] || null, textContent: async () => attrs.text || '' }; }
+  "
+  [ "$output" = "ghp_clipboardToken_123" ]
+}
+
+@test "captureGitHubTokenFromPage captures clipboard-copy text token" {
+  run_js "
+    import { captureGitHubTokenFromPage } from '$SCRIPTS_DIR/token-capture.mjs';
+    const page = fakePage({ 'clipboard-copy': [{ text: 'Copy github_pat_11ABC_def456' }] });
+    console.log(await captureGitHubTokenFromPage(page));
+
+    function fakePage(map) { return { locator: selector => fakeLocator(map[selector] || []), evaluate: async () => null }; }
+    function fakeLocator(elements) { return { count: async () => elements.length, nth: i => fakeElement(elements[i]) }; }
+    function fakeElement(attrs) { return { getAttribute: async name => attrs[name] || null, textContent: async () => attrs.text || '' }; }
+  "
+  [ "$output" = "github_pat_11ABC_def456" ]
+}
+
+@test "captureGitHubTokenFromPage broad DOM fallback returns only token" {
+  run_js "
+    import { captureGitHubTokenFromPage } from '$SCRIPTS_DIR/token-capture.mjs';
+    const page = { locator: () => ({ count: async () => 0 }), evaluate: async () => 'ghp_fallbackToken_123' };
+    console.log(await captureGitHubTokenFromPage(page));
+  "
+  [ "$output" = "ghp_fallbackToken_123" ]
+}
+
+@test "safe diagnostics are structure-first and redact defense-in-depth" {
+  run_js "
+    import { formatPageFacts } from '$SCRIPTS_DIR/page-diagnostics.mjs';
+    const rendered = formatPageFacts({
+      url: 'https://github.com/settings/tokens/new?secret=ghp_urlToken_123#github_pat_hash_456',
+      title: 'Token page for dev@example.com',
+      headings: ['New personal access token ghp_headingToken_123'],
+      alerts: ['Verification code 123456 and recovery a1b2c-3d4e5'],
+      buttons: ['Generate token'],
+      controls: [{
+        tag: 'input', type: 'text', id: 'new-oauth-token', name: 'token',
+        labels: ['Personal access token'], value: 'sk_futureTokenShape_should_not_leak',
+      }, {
+        tag: 'button', type: 'submit', id: 'submit', name: '', text: 'Generate token ghp_buttonToken_123',
+      }],
+    });
+    console.log(rendered);
+  "
+  [[ "$output" == *'"value": "[present]"'* ]]
+  [[ "$output" == *'Generate token [REDACTED_GITHUB_TOKEN]'* ]]
+  [[ "$output" == *'[REDACTED_EMAIL]'* ]]
+  [[ "$output" == *'[REDACTED_RECOVERY_CODE]'* ]]
+  [[ "$output" == *'[REDACTED_CODE]'* ]]
+  [[ "$output" != *'sk_futureTokenShape_should_not_leak'* ]]
+  [[ "$output" != *'ghp_headingToken_123'* ]]
+  [[ "$output" != *'dev@example.com'* ]]
+  [[ "$output" != *'a1b2c-3d4e5'* ]]
+  [[ "$output" != *'123456'* ]]
+}


### PR DESCRIPTION
## Summary

- Extract shared GitHub PAT capture helper for create/regenerate success pages.
- Use the helper from both `token-create.mjs` and `token-rotate.mjs`, including broad DOM fallback that returns only the captured token.
- Add structure-first safe page diagnostics and wire them into auth/page-shape/capture failures.
- Add a non-mutating `github:token:diagnose` page-shape diagnostic task.

This intentionally keeps #33 narrow: it hardens capture after the existing create/regenerate flows, but does not implement the broader create-then-delete rotation strategy from #10.

Fixes #33.
Fixes #34.

## Safety

- No live token create/regenerate testing performed.
- Diagnostics omit arbitrary input/control values by default and use `[present]` markers.
- Redaction remains defense-in-depth for headings, alerts, labels, button text, URLs, and other structural strings.

## Tests

- `node --check scripts/github/page-diagnostics.mjs scripts/github/token-capture.mjs scripts/github/token-diagnose.mjs scripts/github/token-create.mjs scripts/github/token-rotate.mjs`
- `git diff --check`
- Full BATS suite via direct bats install path with libexec shims (the `mise` bats shim in this runner is missing libexec on PATH):
  - `1..88` all passing
